### PR TITLE
Build and install script fixes

### DIFF
--- a/User Tools/iSCSICtl.m
+++ b/User Tools/iSCSICtl.m
@@ -385,7 +385,7 @@ void iSCSICtlDisplayUsage()
                                 "       iscsictl remove discovery-portal <portal>\n\n"));
                                         
     iSCSICtlDisplayString(CFSTR("       iscsictl list targets\n"
-                                "       iscsictl list lun\n"));
+                                "       iscsictl list luns\n"));
 }
 
 CFStringRef iSCSICtlCreateSecretFromInput(CFIndex retries)

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
-xcodebuild -scheme iscsid build
+xcodebuild -scheme iSCSIDaemon build
 xcodebuild -scheme iscsictl build
 xcodebuild -scheme iSCSIInitiator build

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,22 @@ DAEMON=iscsid
 TOOL=iscsictl
 KEXT=iSCSIInitiator.kext
 
-# Define paths
-SOURCE_PATH=./DerivedData/Build/Products/Debug
+# Look for build products in places Xcode might place them.
+for BUILD_PATH in \
+            ./DerivedData/Build/Products/Debug \
+            ./DerivedData/iSCSIInitiator/Build/Products/Debug \
+            ~/Library/Developer/Xcode/DerivedData/iSCSIInitiator*/Build/Products/Debug \
+            ; do
+    if [ -d "${BUILD_PATH}" ]; then
+        SOURCE_PATH="${BUILD_PATH}"
+        break;
+    fi
+done
+
+if [ X"" == X"${SOURCE_PATH}" ]; then
+    echo "Unable to locate iSCSIInitiator binaries; did you run build.sh without errors?"
+    exit 1
+fi
 
 # Copy kernel extension & load it
 sudo cp -R $SOURCE_PATH/$KEXT /Library/Extensions/$KEXT


### PR DESCRIPTION
The build script uses the old iSCSI daemon name; I've updated it to reflect the new name.

The install script has been extended to work with the default Xcode 7.1 beta 3 build directories; it looks for build products in multiple locations.