### PR TITLE
Fix compilation failure due to missing "asl_object_t".

### DIFF
--- a/Source/User Tools/iSCSIDaemon.c
+++ b/Source/User Tools/iSCSIDaemon.c
@@ -1257,7 +1257,7 @@ void iSCSIDAcceptConnection(CFSocketRef socket,
 int main(void)
 {
     // Initialize logging
-    asl_object_t log = asl_open(NULL,NULL,ASL_OPT_STDERR);
+    aslclient log = asl_open(NULL,NULL,ASL_OPT_STDERR);
 
     // Read configuration parameters from the iSCSI property list
     iSCSIPLSynchronize();


### PR DESCRIPTION
According to Apple's developer website, the correct name is (and always was) "aslclient".
Checked in current released and pre-release documentation.  This addresses issue #30 