### PR TITLE
Remove remaining CFStringGetCStringPtr

### DIFF
--- a/Source/User/iSCSI Framework/iSCSIUtils.c
+++ b/Source/User/iSCSI Framework/iSCSIUtils.c
@@ -49,11 +49,16 @@ Boolean iSCSIUtilsValidateIQN(CFStringRef IQN)
     Boolean validName = false;
     regex_t preg;
     regcomp(&preg,pattern,REG_EXTENDED | REG_NOSUB);
+    size_t      iqnLength = CFStringGetLength(IQN);
+    char *      iqnCStr = (char *)malloc(iqnLength + 1);
+    CFStringGetCString(IQN, iqnCStr, iqnLength + 1, kCFStringEncodingASCII);
     
-    if(regexec(&preg,CFStringGetCStringPtr(IQN,kCFStringEncodingASCII),0,NULL,0) == 0)
+    
+    if(regexec(&preg,iqnCStr,0,NULL,0) == 0)
         validName = true;
     
     regfree(&preg);
+    free(iqnCStr);
     return validName;
 }
 
@@ -102,14 +107,20 @@ CFArrayRef iSCSIUtilsCreateArrayByParsingPortalParts(CFStringRef portal)
         regmatch_t matches[maxMatches[index]];
         memset(matches,0,sizeof(regmatch_t)*maxMatches[index]);
         
+        size_t      portalLength = CFStringGetLength(portal);
+        char *      portalCStr = (char *)malloc(portalLength + 1);
+        CFStringGetCString(portal, portalCStr, portalLength + 1, kCFStringEncodingASCII);
+        
         // Match against pattern[index]
-        if(regexec(&preg,CFStringGetCStringPtr(portal,kCFStringEncodingASCII),maxMatches[index],matches,0))
+        if(regexec(&preg,portalCStr,maxMatches[index],matches,0))
         {
             regfree(&preg);
             index++;
+            free(portalCStr);
             continue;
         }
         
+        free(portalCStr);
         CFMutableArrayRef portalParts = CFArrayCreateMutable(kCFAllocatorDefault,0,&kCFTypeArrayCallBacks);
         
         // Get the host name

--- a/Source/User/iscsid/iSCSIAuth.c
+++ b/Source/User/iscsid/iSCSIAuth.c
@@ -49,7 +49,9 @@ CFDataRef CFDataCreateWithHexString(CFStringRef hexStr)
 
     // Get length and pointer to hex string
     CFIndex hexStrLen = CFStringGetLength(hexStr);
-    const char * hexStrPtr = CFStringGetCStringPtr(hexStr,kCFStringEncodingASCII);
+    
+    char * hexStrPtr = malloc(hexStrLen + 1);
+    CFStringGetCString(hexStr, hexStrPtr, hexStrLen + 1, kCFStringEncodingASCII);
 
     // Byte length stars off as the number of hex characters, and is adjusted
     // to reflect the number of bytes depending on the format of the hex string
@@ -96,7 +98,8 @@ CFDataRef CFDataCreateWithHexString(CFStringRef hexStr)
         bytes[byteIdx] = buffer;
         byteIdx++;
     }
-
+    
+    free(hexStrPtr);
     return data;
 }
 
@@ -143,7 +146,9 @@ CFStringRef iSCSIAuthNegotiateCHAPCreateResponse(CFStringRef identifier,
     CC_MD5_Update(&md5,&id,(CC_LONG)sizeof(id));
 
     // Hash in the secret
-    const UInt8 * byteSecret = (const UInt8*)CFStringGetCStringPtr(secret,kCFStringEncodingASCII);
+    size_t secretLength = CFStringGetLength(secret);
+    UInt8 * byteSecret = malloc(secretLength + 1);
+    CFStringGetCString(secret, (char *)byteSecret, secretLength + 1, kCFStringEncodingASCII);
     CC_MD5_Update(&md5,byteSecret,(CC_LONG)CFStringGetLength(secret));
 
     // Hash in the challenge
@@ -155,7 +160,8 @@ CFStringRef iSCSIAuthNegotiateCHAPCreateResponse(CFStringRef identifier,
     CC_MD5_Final(md5Hash,&md5);
 
     CFRelease(challengeData);
-
+    free(byteSecret);
+    
     return CreateHexStringWithBytes(md5Hash,CC_MD5_DIGEST_LENGTH);
 }
 

--- a/Source/User/iscsid/iSCSIDaemon.c
+++ b/Source/User/iscsid/iSCSIDaemon.c
@@ -350,7 +350,13 @@ errno_t iSCSIDLoginCommon(SID sessionId,
             iSCSIPortalGetPort(portal),
             strerror(error));
 
-        asl_log(NULL,NULL,ASL_LEVEL_ERR,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+        size_t errorStringLength = CFStringGetLength(errorString);
+        char * errorStringCStr = malloc(errorStringLength + 1);
+        CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+
+        asl_log(NULL, NULL, ASL_LEVEL_ERR, "%s", errorStringCStr);
+        
+        free(errorStringCStr);
         CFRelease(errorString);
     }
     // Update target alias in preferences (if one was furnished)
@@ -647,7 +653,13 @@ void iSCSIDLogoutComplete(iSCSITargetRef target,enum iSCSIDAOperationResult resu
                 strerror(errorCode));
         }
         
-        asl_log(NULL,NULL,ASL_LEVEL_ERR,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+        size_t errorStringLength = CFStringGetLength(errorString);
+        char * errorStringCStr = malloc(errorStringLength + 1);
+        CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+        
+        asl_log(NULL, NULL, ASL_LEVEL_ERR, "%s", errorStringCStr);
+        
+        free(errorStringCStr);
         CFRelease(errorString);
     }
 
@@ -718,7 +730,13 @@ errno_t iSCSIDLogout(int fd,iSCSIDMsgLogoutCmd * cmd)
             CFSTR("logout of %@ failed: the target has no active sessions"),
             iSCSITargetGetIQN(target));
         
-        asl_log(0,0,ASL_LEVEL_CRIT,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+        size_t errorStringLength = CFStringGetLength(errorString);
+        char * errorStringCStr = malloc(errorStringLength + 1);
+        CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+        
+        asl_log(NULL, NULL, ASL_LEVEL_CRIT, "%s", errorStringCStr);
+        
+        free(errorStringCStr);
         CFRelease(errorString);
         errorCode = EINVAL;
     }
@@ -737,7 +755,13 @@ errno_t iSCSIDLogout(int fd,iSCSIDMsgLogoutCmd * cmd)
                 CFSTR("logout of %@,%@:%@ failed: the portal has no active connections"),
                 iSCSITargetGetIQN(target),iSCSIPortalGetAddress(portal),iSCSIPortalGetPort(portal));
         
-            asl_log(0,0,ASL_LEVEL_CRIT,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+            size_t errorStringLength = CFStringGetLength(errorString);
+            char * errorStringCStr = malloc(errorStringLength + 1);
+            CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+            
+            asl_log(NULL, NULL, ASL_LEVEL_CRIT, "%s", errorStringCStr);
+            
+            free(errorStringCStr);
             CFRelease(errorString);
             errorCode = EINVAL;
         }

--- a/Source/User/iscsid/iSCSIDiscovery.c
+++ b/Source/User/iscsid/iSCSIDiscovery.c
@@ -98,8 +98,13 @@ errno_t iSCSIDiscoveryUpdatePreferencesWithDiscoveredTargets(iSCSIPreferencesRef
                 CFSTR("discovered target %@ already exists with static configuration."),
                 targetIQN);
 
-            asl_log(NULL,NULL,ASL_LEVEL_INFO,"%s",CFStringGetCStringPtr(statusString,kCFStringEncodingASCII));
-
+            size_t statusStringLength = CFStringGetLength(statusString);
+            char * statusStringCStr = malloc(statusStringLength + 1);
+            CFStringGetCString(statusString, statusStringCStr, statusStringLength + 1, kCFStringEncodingASCII);
+            
+            asl_log(NULL, NULL, ASL_LEVEL_INFO, "%s", statusStringCStr);
+            
+            free(statusStringCStr);
             CFRelease(statusString);
         }
         // Target doesn't exist, or target exists with SendTargets
@@ -111,8 +116,13 @@ errno_t iSCSIDiscoveryUpdatePreferencesWithDiscoveredTargets(iSCSIPreferencesRef
                 CFSTR("discovered target %@ over discovery portal %@."),
                 targetIQN,discoveryPortal);
 
-            asl_log(NULL,NULL,ASL_LEVEL_INFO,"%s",CFStringGetCStringPtr(statusString,kCFStringEncodingASCII));
-
+            size_t statusStringLength = CFStringGetLength(statusString);
+            char * statusStringCStr = malloc(statusStringLength + 1);
+            CFStringGetCString(statusString, statusStringCStr, statusStringLength + 1, kCFStringEncodingASCII);
+            
+            asl_log(NULL, NULL, ASL_LEVEL_INFO, "%s", statusStringCStr);
+            
+            free(statusStringCStr);
             CFRelease(statusString);
         }
 
@@ -205,7 +215,13 @@ CFDictionaryRef iSCSIDiscoveryCreateRecordsWithSendTargets(iSCSIPreferencesRef p
                 CFSTR("system error (code %d) occurred during SendTargets discovery of %@."),
                 error,discoveryPortal);
 
-            asl_log(NULL,NULL,ASL_LEVEL_ERR,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+            size_t errorStringLength = CFStringGetLength(errorString);
+            char * errorStringCStr = malloc(errorStringLength + 1);
+            CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+            
+            asl_log(NULL, NULL, ASL_LEVEL_ERR, "%s", errorStringCStr);
+            
+            free(errorStringCStr);
             CFRelease(errorString);
         }
         else if(statusCode != kiSCSILoginSuccess) {
@@ -214,7 +230,13 @@ CFDictionaryRef iSCSIDiscoveryCreateRecordsWithSendTargets(iSCSIPreferencesRef p
                 CFSTR("login failed with (code %d) during SendTargets discovery of %@."),
                 statusCode,discoveryPortal);
             
-            asl_log(NULL,NULL,ASL_LEVEL_ERR,"%s",CFStringGetCStringPtr(errorString,kCFStringEncodingASCII));
+            size_t errorStringLength = CFStringGetLength(errorString);
+            char * errorStringCStr = malloc(errorStringLength + 1);
+            CFStringGetCString(errorString, errorStringCStr, errorStringLength + 1, kCFStringEncodingASCII);
+            
+            asl_log(NULL, NULL, ASL_LEVEL_ERR, "%s", errorStringCStr);
+            
+            free(errorStringCStr);
             CFRelease(errorString);
         }
         else {


### PR DESCRIPTION
Replace them in most cases with CFStringGetCString
Where applicable, just change the string creation process to
avoid the CFStringRef step entirely

Fixes #55