### PR TITLE
fix MAN_DST for macOS 10.15

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -14,7 +14,7 @@ DAEMON_DST=/usr/local/libexec
 DAEMON_PLIST_DST=/Library/LaunchDaemons
 FRAMEWORK_DST=/Library/Frameworks
 TOOL_DST=/usr/local/bin
-MAN_DST=/usr/share/man/man8
+MAN_DST=/usr/local/share/man/man8
 PREF_DST=/Library/Preferences
 PREF_FILE=com.github.iscsi-osx.iSCSIInitiator.plist
 


### PR DESCRIPTION
fix https://github.com/iscsi-osx/iSCSIInitiator/issues/113
> sudo ./install.sh
cp: cannot create regular file '/usr/share/man/man8/iscsictl.8': Read-only file system
cp: cannot create regular file '/usr/share/man/man8/iscsid.8': Read-only file system