### PR TITLE
Fix the uninstall MAN_DST parameter in macOS 10.15

### DIFF
--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -14,7 +14,7 @@ DAEMON_DST=/usr/local/libexec
 DAEMON_PLIST_DST=/Library/LaunchDaemons
 FRAMEWORK_DST=/Library/Frameworks
 TOOL_DST=/usr/local/bin
-MAN_DST=/usr/share/man/man8
+MAN_DST=/usr/local/share/man/man8
 PREF_DST=/Library/Preferences
 PREF_FILE=com.github.iscsi-osx.iSCSIInitiator.plist
 


### PR DESCRIPTION
4ft35t fixed #113, but it seems that he forgot to update the uninstall.sh file.