### PR TITLE
docs: fix simple typo, exhausitve -> exhaustive

### DIFF
--- a/Source/User/iSCSI Framework/iSCSIIORegistry.c
+++ b/Source/User/iSCSI Framework/iSCSIIORegistry.c
@@ -222,7 +222,7 @@ io_object_t iSCSIIORegistryFindIOMediaForLUN(io_object_t LUN)
 }
 
 /*! Creates a dictionary of properties associated with the target.  These
- *  include the following keys (not exhausitve, see OS X documentation):
+ *  include the following keys (not exhaustive, see OS X documentation):
  *
  *  kIOPropertySCSIVendorIdentification (CFStringRef)
  *  kIOPropertySCSIProductIdentification (CFStringRef)


### PR DESCRIPTION
There is a small typo in Source/User/iSCSI Framework/iSCSIIORegistry.c.

Should read `exhaustive` rather than `exhausitve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md